### PR TITLE
fix: correctly init status counter for multipage

### DIFF
--- a/pkg/platforms/github.go
+++ b/pkg/platforms/github.go
@@ -174,18 +174,21 @@ func (p *githubPlatform) CheckAllStatusSucceeded(owner, repository,
 		},
 	}
 
+	succeededCheck := 0
 	for {
 		getCheckRun, resp, err := p.client.Checks.ListCheckRunsForRef(p.context,
 			owner, repository, commitSha, opts)
 		if err != nil {
 			return false, err
 		}
-
-		succeededCheck := 0
 		// TODO: make sure all values in statuses are unique
 		for _, check := range getCheckRun.CheckRuns {
 			for _, status := range statuses {
-				if *check.Name == status && check.Conclusion != nil && *check.Conclusion == successStatusValue {
+				if *check.Name == status &&
+					check.Status != nil &&
+					*check.Status == completedStatusValue &&
+					check.Conclusion != nil &&
+					*check.Conclusion == successStatusValue {
 					succeededCheck++
 				}
 			}

--- a/pkg/platforms/github_test.go
+++ b/pkg/platforms/github_test.go
@@ -63,7 +63,7 @@ func TestGithubListReleases(t *testing.T) {
 
 		result, err := gh.ListReleases("a", "a")
 		if err != nil {
-			t.Error("Error listing draft releases", err)
+			t.Errorf("Error listing releases: %#v", err)
 		}
 		if diff := pretty.Compare(result, expected); diff != "" {
 			t.Errorf("diff: (-got +want)\n%s", diff)
@@ -113,7 +113,159 @@ func TestGithubListDraftReleases(t *testing.T) {
 
 		result, err := gh.ListDraftReleases("a", "a")
 		if err != nil {
-			t.Error("Error listing draft releases", err)
+			t.Errorf("Error listing draft releases: %#v", err)
+		}
+		if diff := pretty.Compare(result, expected); diff != "" {
+			t.Errorf("diff: (-got +want)\n%s", diff)
+		}
+	})
+}
+
+func TestGithubCheckAllStatusSucceeded(t *testing.T) {
+	testCases := []struct {
+		name      string
+		checkRuns []*github.CheckRun
+		statuses  []string
+		expected  bool
+	}{
+		{
+			name: "should return true if all required check runs completed and conclusion set to success",
+			checkRuns: []*github.CheckRun{
+				{
+					Name:       github.String("happy flow"),
+					Status:     github.String("completed"),
+					Conclusion: github.String("success"),
+				},
+				{
+					Name:       github.String("no required check run"),
+					Status:     github.String("pending"),
+					Conclusion: github.String(""),
+				},
+				{
+					Name:       github.String("feature B"),
+					Status:     github.String("completed"),
+					Conclusion: github.String("success"),
+				},
+			},
+			statuses: []string{"happy flow", "feature B"},
+			expected: true,
+		},
+		{
+			name: "should return false if all check runs completed and not all conclusion are set to success",
+			checkRuns: []*github.CheckRun{
+				{
+					Name:       github.String("happy flow"),
+					Status:     github.String("completed"),
+					Conclusion: github.String("success"),
+				},
+				{
+					Name:       github.String("feature A"),
+					Status:     github.String("completed"),
+					Conclusion: github.String("skipped"),
+				},
+				{
+					Name:       github.String("feature B"),
+					Status:     github.String("completed"),
+					Conclusion: github.String("failure"),
+				},
+			},
+			statuses: []string{"happy flow", "feature A", "feature B"},
+			expected: false,
+		},
+		{
+			name: "should return false if not all check runs completed",
+			checkRuns: []*github.CheckRun{
+				{
+					Name:       github.String("happy flow"),
+					Status:     github.String("completed"),
+					Conclusion: github.String("success"),
+				},
+				{
+					Name:       github.String("feature A"),
+					Status:     github.String("pending"),
+					Conclusion: github.String(""),
+				},
+				{
+					Name:       github.String("feature B"),
+					Status:     github.String("completed"),
+					Conclusion: github.String("success"),
+				},
+			},
+			statuses: []string{"happy flow", "feature A", "feature B"},
+			expected: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			mockedHTTPClient := mock.NewMockedHTTPClient(
+				mock.WithRequestMatch(
+					mock.GetReposCommitsCheckRunsByOwnerByRepoByRef,
+					github.ListCheckRunsResults{CheckRuns: testCase.checkRuns},
+				),
+			)
+
+			gh := githubPlatform{
+				client:  github.NewClient(mockedHTTPClient),
+				context: context.Background(),
+			}
+
+			result, err := gh.CheckAllStatusSucceeded("a", "a", "a", testCase.statuses)
+			if err != nil {
+				t.Errorf("Error checking status check: %#v", err)
+			}
+			if result != testCase.expected {
+				t.Errorf("Expected %t, got %t", testCase.expected, result)
+			}
+		})
+	}
+}
+
+func TestGithubListStatuses(t *testing.T) {
+	t.Run("should list statuses", func(t *testing.T) {
+		expected := []*Status{
+			{
+				CommitSha: "abcd1234",
+				Name:      "happy flow",
+				Status:    "completed",
+				State:     "success",
+			},
+			{
+				CommitSha: "abcd1234",
+				Name:      "feature A",
+				Status:    "queued",
+				State:     "",
+			},
+		}
+
+		mockedHTTPClient := mock.NewMockedHTTPClient(
+			mock.WithRequestMatch(
+				mock.GetReposCommitsCheckRunsByOwnerByRepoByRef,
+				github.ListCheckRunsResults{CheckRuns: []*github.CheckRun{
+					{
+						HeadSHA:    github.String("abcd1234"),
+						Name:       github.String("happy flow"),
+						Status:     github.String("completed"),
+						Conclusion: github.String("success"),
+					},
+					{
+						HeadSHA: github.String("abcd1234"),
+						Name:    github.String("feature A"),
+						Status:  github.String("queued"),
+					},
+				},
+				},
+			),
+		)
+
+		gh := &githubPlatform{
+			client:  github.NewClient(mockedHTTPClient),
+			context: context.Background(),
+		}
+
+		result, err := gh.ListStatuses("a", "a", "a")
+		if err != nil {
+			t.Errorf("Error listing statuses: %#v", err)
 		}
 		if diff := pretty.Compare(result, expected); diff != "" {
 			t.Errorf("diff: (-got +want)\n%s", diff)

--- a/pkg/platforms/gitlab.go
+++ b/pkg/platforms/gitlab.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	// default number of items per page to retrieve via the Gitlab API
-	gitlabePerPage int = 100
+	gitlabPerPage int = 100
 
 	// default number of hours to set a future release to (aka draft release)
 	// Gitlab doesn't distinguish between draft and published release but use
@@ -60,7 +60,7 @@ func (p *gitlabPlatform) ReadFile(owner, repository, path string) (content io.Re
 func (p *gitlabPlatform) ListReleases(owner, repository string) (releases []*Release, err error) {
 	opts := &gitlab.ListReleasesOptions{
 		Page:    0,
-		PerPage: gitlabePerPage,
+		PerPage: gitlabPerPage,
 	}
 
 	for {
@@ -162,10 +162,11 @@ func (p *gitlabPlatform) CheckAllStatusSucceeded(owner, repository,
 	opts := &gitlab.GetCommitStatusesOptions{
 		ListOptions: gitlab.ListOptions{
 			Page:    0,
-			PerPage: gitlabePerPage,
+			PerPage: gitlabPerPage,
 		},
 	}
 
+	succeededStatus := 0
 	for {
 		commitStatuses, resp, err := p.client.Commits.GetCommitStatuses(getPID(
 			owner, repository), commitSha, opts, nil)
@@ -174,7 +175,6 @@ func (p *gitlabPlatform) CheckAllStatusSucceeded(owner, repository,
 		}
 
 		// for all statuses, check if the provided one are all successful
-		succeededStatus := 0
 		for _, commitStatus := range commitStatuses {
 			for _, status := range statuses {
 				if commitStatus.Name == status && commitStatus.Status == successStatusValue {

--- a/pkg/platforms/platforms.go
+++ b/pkg/platforms/platforms.go
@@ -7,6 +7,9 @@ import (
 const (
 	// Success status value
 	successStatusValue = "success"
+
+	// Completed status value
+	completedStatusValue = "completed"
 )
 
 // Platform interface Github and Gitlab


### PR DESCRIPTION
Counter was initialized outside of the provider pagination logic which could have caused problems if a commit contained more than 100 checks.