### PR TITLE
fix: revert GitHub token authentication

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,7 +35,6 @@ func init() {
 	flags.Int64("github.installationID", 0, "Github Installation ID")
 	flags.String("github.privateKeyPath", "", "Github private key path")
 	flags.String("github.webhookSecret", "", "Github webhook secret")
-	flags.String("github.token", "", "Github token (prefer private key authentication instead)")
 	flags.String("gitlab.token", "", "Gitlab Token")
 	flags.String("logLevel", "info", "Log level: trace, debug, info, warn,"+
 		"error, fatal or panic")

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -18,7 +18,6 @@ func newPlatform() (platform platforms.Platform, err error) {
 			AppID:          config.Main.Github.AppID,
 			InstallationID: config.Main.Github.InstallationID,
 			PrivateKeyPath: config.Main.Github.PrivateKeyPath,
-			Token:          config.Main.Github.Token,
 		})
 	default:
 		err = fmt.Errorf("platform %s is not recognized", *config.Main.Platform)

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/viper v1.10.1
 	github.com/xanzy/go-gitlab v0.61.0
-	golang.org/x/oauth2 v0.0.0-20220309155454-6242fa91716a
 )
 
 require (
@@ -47,6 +46,7 @@ require (
 	github.com/subosito/gotenv v1.2.0 // indirect
 	golang.org/x/crypto v0.0.0-20220331220935-ae2d96664a29 // indirect
 	golang.org/x/net v0.0.0-20220403103023-749bd193bc2b // indirect
+	golang.org/x/oauth2 v0.0.0-20220309155454-6242fa91716a // indirect
 	golang.org/x/sys v0.0.0-20220405052023-b1e9470b6e64 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20220224211638-0e9765cccd65 // indirect

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -113,7 +113,6 @@ type Github struct {
 	AppID          int64  `mapstructure:"appID"`
 	InstallationID int64  `mapstructure:"installationID"`
 	PrivateKeyPath string `mapstructure:"privateKeyPath"`
-	Token          string `mapstructure:"token"`
 }
 
 // Gitlab define Gitlab configuration

--- a/pkg/platforms/github.go
+++ b/pkg/platforms/github.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/bradleyfalzon/ghinstallation/v2"
 	"github.com/google/go-github/v43/github"
-	"golang.org/x/oauth2"
 )
 
 const (
@@ -20,7 +19,6 @@ type GithubConfig struct {
 	AppID          int64
 	InstallationID int64
 	PrivateKeyPath string
-	Token          string
 }
 
 type githubPlatform struct {
@@ -30,33 +28,22 @@ type githubPlatform struct {
 }
 
 // NewGithub returns an instance of platform
-func NewGithub(config *GithubConfig) (Platform, error) {
+func NewGithub(config *GithubConfig) (platform Platform, err error) {
 	ctx := context.Background()
 
-	platform := &githubPlatform{
+	itr, err := ghinstallation.NewKeyFromFile(http.DefaultTransport,
+		config.AppID, config.InstallationID, config.PrivateKeyPath)
+	if err != nil {
+		return
+	}
+
+	platform = &githubPlatform{
 		config:  config,
 		context: ctx,
+		client:  github.NewClient(&http.Client{Transport: itr}),
 	}
 
-	// GitHub private key or token based authentication
-	if config.Token == "" {
-		itr, err := ghinstallation.NewKeyFromFile(http.DefaultTransport,
-			config.AppID, config.InstallationID, config.PrivateKeyPath)
-		if err != nil {
-			return nil, err
-		}
-
-		platform.client = github.NewClient(&http.Client{Transport: itr})
-	} else {
-		ts := oauth2.StaticTokenSource(
-			&oauth2.Token{AccessToken: config.Token},
-		)
-		tc := oauth2.NewClient(ctx, ts)
-
-		platform.client = github.NewClient(tc)
-	}
-
-	return platform, nil
+	return
 }
 
 // ReadFile retrieve file located at the provided path in a given Github repository


### PR DESCRIPTION
Revert GitHub token authentication introduced by
https://github.com/FikaWorks/grgate/pull/20.

It cannot be used due to limitation, the GitHub API only allow GitHub Apps
authentication to interact with checks.